### PR TITLE
Sanitize out file name

### DIFF
--- a/src/schema/exporter/TS.ts
+++ b/src/schema/exporter/TS.ts
@@ -2,7 +2,7 @@
 // Released under the MIT license, see LICENSE.
 
 import { MemberRef } from "@loanlink-nl/cxml";
-import path from "path";
+import * as path from "node:path";
 import { Exporter } from "./Exporter";
 import { Type } from "../Type";
 


### PR DESCRIPTION
Fix error where file names generated contains http:/ prefix by sanitizing the file name
Fixes to #298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exported TypeScript files now use only the base name of the source (ignoring directory paths), producing clean “.ts” filenames.
  * Prevents malformed filenames that included path segments, improving compatibility with tooling and avoiding potential collisions or overwrites when exporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->